### PR TITLE
readme.mdにnodeのバージョン要求を追記

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ A lean, gulp-based HTML & SASS boilerplate for better front-end coding.
 
 - Node.js
     - <http://nodejs.org/>
+    - **v0.10.x** is needed.
 
 ## Set Up
 


### PR DESCRIPTION
### 概要
nodeの最新安定版である0.12.x系で npm install したところ，gulp-pleeease が依存している fsevents のnodeの要求バージョンが古いようで，エラーが出ました．
gulp-pleeeaseのバージョンを1.2.0としたらエラーはおきなかったことと，1.1.0のままでもnode v0.10.36では特に問題はありませんでしたので．nodeの推奨バージョン要求を追記したほうが良いと考え．提案いたします．