### PR TITLE
node v0.12.xに対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "gulp-uglify": "~1.1.0",
     "gulp-imagemin": "~2.2.0",
     "browser-sync": "~2.0.1",
-    "gulp-pleeease": "~1.1.0"
+    "gulp-pleeease": "~1.2.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ A lean, gulp-based HTML & SASS boilerplate for better front-end coding.
 
 - Node.js
     - <http://nodejs.org/>
+    - v0.12.x is recommended.
 
 ## Set Up
 


### PR DESCRIPTION
### このPRの目的
node v0.12.xでも致命的なエラーなく使えるようにします．

#### 経緯
今すぐにnode v0.12系に対応される予定はないかもしれませんが，自分の環境で動かすまでに試行錯誤したので参考までにPRしておきます．
他の依存ソフトウェアもバージョンを挙げられそうですが最低限エラーを無くすようにしました．

余談ですが，Rinではじめてフロントを触りましたが楽しかったです．（告知サイトのCSS周りも非常に参考にさせていただきました）開発ありがとうございます！

### 問題点
nodeの最新安定版（v0.12.7）で `npm install` すると gulp-pleeease の fsevents で fatal error になる．

#### 検証環境
- Mac OS X Yosemite
- node -v v0.12.7
- node-gyp -v v2.0.1
- npm -v 2.12.1

### 解決策
gulp-pleeease を最新版（v1.2.0）にする．

ただし，./gulp-pleeease/node_modules/pleeease/node_modules/postcss-url/node_modules/directory-encoderのpackage.jsonの依存しているimg-statsのnodeの要求バージョンが古いためwarnigが出ます．
> img-stats@0.4.2: wanted: {"node":"~0.10"}
