### PR TITLE
Fixed Dependency version for gulp-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulp-imagemin": "~2.2.0",
     "gulp-pleeease": "~1.2.0",
     "gulp-plumber": "^1.0.1",
-    "gulp-sass": "~1.3.3",
+    "gulp-sass": "~2.3.1",
     "gulp-uglify": "~1.1.0"
   }
 }


### PR DESCRIPTION
npm install fails due to old version of gulp-sass. Updated gulp-sass to latest version.